### PR TITLE
be much more quiet on success.  

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -60,6 +60,12 @@ Then download the runtime + commit it to your repo + run with runtime
 forking-test-runner test --group 1 --groups 20 --runtime-log test/files/runtime.log
 ```
 
+### Only provide output from failed tests
+
+```
+forking-test-runner test --quiet
+```
+
 ### RSpec
 
 Just add `--rspec`

--- a/gemfiles/32.gemfile.lock
+++ b/gemfiles/32.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.4.5)
+    forking_test_runner (0.4.6)
       activerecord (< 5.0.0)
       parallel_tests (>= 1.3.7)
 
@@ -26,8 +26,8 @@ GEM
     i18n (0.7.0)
     minitest (4.7.5)
     multi_json (1.11.0)
-    parallel (1.4.1)
-    parallel_tests (1.3.7)
+    parallel (1.6.0)
+    parallel_tests (1.3.9)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/40.gemfile.lock
+++ b/gemfiles/40.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.4.5)
+    forking_test_runner (0.4.6)
       activerecord (< 5.0.0)
       parallel_tests (>= 1.3.7)
 
@@ -30,8 +30,8 @@ GEM
     i18n (0.7.0)
     minitest (4.7.5)
     multi_json (1.11.0)
-    parallel (1.4.1)
-    parallel_tests (1.3.7)
+    parallel (1.6.0)
+    parallel_tests (1.3.9)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/41.gemfile.lock
+++ b/gemfiles/41.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.4.5)
+    forking_test_runner (0.4.6)
       activerecord (< 5.0.0)
       parallel_tests (>= 1.3.7)
 
@@ -28,8 +28,8 @@ GEM
     i18n (0.7.0)
     json (1.8.2)
     minitest (5.5.1)
-    parallel (1.4.1)
-    parallel_tests (1.3.7)
+    parallel (1.6.0)
+    parallel_tests (1.3.9)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/42.gemfile.lock
+++ b/gemfiles/42.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.4.5)
+    forking_test_runner (0.4.6)
       activerecord (< 5.0.0)
       parallel_tests (>= 1.3.7)
 
@@ -28,8 +28,8 @@ GEM
     i18n (0.7.0)
     json (1.8.2)
     minitest (5.5.1)
-    parallel (1.4.1)
-    parallel_tests (1.3.7)
+    parallel (1.6.0)
+    parallel_tests (1.3.9)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -30,7 +30,7 @@ module ForkingTestRunner
         puts "#{CLEAR} >>> #{file} "
         time, success, output = benchmark { run_test(file) }
 
-        puts output if should_output?(output)
+        puts output if !success || @verbose
 
         puts "Time: expected #{expected.round(2)}, actual #{time.round(2)}" if runtime_log && @verbose
         puts "#{CLEAR} <<< #{file} ---- #{success ? "OK" : "Failed"}" if @verbose
@@ -61,16 +61,6 @@ module ForkingTestRunner
     end
 
     private
-
-    def should_output?(output)
-      if output =~ /\d+ tests, \d+ assertions, (\d+) failures, (\d+) errors, \d+ skips/
-        failures, errors = $1, $2
-        failures.to_i + errors.to_i > 0
-      else
-        true
-      end
-    end
-
 
     def benchmark
       result = false

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -5,7 +5,6 @@ describe ForkingTestRunner do
   let(:root) { File.expand_path("../../", __FILE__) }
 
   def runner(command, options={})
-    command += " --verbose" unless options[:verbose] == false
     sh("bundle exec #{root}/bin/forking-test-runner #{command}", options)
   end
 
@@ -108,6 +107,18 @@ describe ForkingTestRunner do
     result = runner("test/no_ar_test.rb --helper test/no_ar_helper.rb")
     result.should =~ /1 tests, 1 assertions|1 runs, 1 assertions/
     result.should include "AR IS UNDEFINED"
+  end
+
+  it "can run quietly" do
+    result = runner("test --quiet")
+    result.should_not include "# Running tests:"
+  end
+
+  it "will output failures normally in quiet mode" do
+    with_env "FAIL_NOW" => "1" do
+      result = runner("test --quiet", fail: true)
+      result.should include "# Running tests:"
+    end
   end
 
   describe "rspec" do

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -5,6 +5,7 @@ describe ForkingTestRunner do
   let(:root) { File.expand_path("../../", __FILE__) }
 
   def runner(command, options={})
+    command += " --verbose" unless options[:verbose] == false
     sh("bundle exec #{root}/bin/forking-test-runner #{command}", options)
   end
 

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -111,13 +111,13 @@ describe ForkingTestRunner do
 
   it "can run quietly" do
     result = runner("test --quiet")
-    result.should_not include "# Running tests:"
+    result.should_not include "Finished"
   end
 
   it "will output failures normally in quiet mode" do
     with_env "FAIL_NOW" => "1" do
       result = runner("test --quiet", fail: true)
-      result.should include "# Running tests:"
+      result.should include "Finished"
     end
   end
 


### PR DESCRIPTION
Capture the output of the child via pipes and eat it on success, unless `--verbose` is specified.

@grosser 