### PR TITLE
Propagate RSpec exit code from the child process

### DIFF
--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -85,11 +85,11 @@ module ForkingTestRunner
 
     def summarize_results(results)
       runner = if @rspec
-        require 'parallel_tests/test/runner'
-        ParallelTests::Test::Runner
-      else
         require 'parallel_tests/rspec/runner'
         ParallelTests::RSpec::Runner
+      else
+        require 'parallel_tests/test/runner'
+        ParallelTests::Test::Runner
       end
 
       runner.summarize_results(results.map { |r| runner.find_results(r) })

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -284,7 +284,7 @@ module ForkingTestRunner
     def toggle_test_autorun(value, file=nil)
       if @rspec
         if value
-          RSpec::Core::Runner.run([file] + ARGV)
+          exit(RSpec::Core::Runner.run([file] + ARGV))
         else
           require 'bundler/setup'
           require 'rspec'

--- a/spec/dummy/spec/failing/simple_spec.rb
+++ b/spec/dummy/spec/failing/simple_spec.rb
@@ -1,0 +1,5 @@
+require "spec_helper"
+
+describe "Foo" do
+  it { expect(false).to be true }
+end

--- a/spec/dummy/spec/passing/simple_spec.rb
+++ b/spec/dummy/spec/passing/simple_spec.rb
@@ -1,7 +1,5 @@
 require "spec_helper"
 
 describe "Foo" do
-  it "bar" do
-    true.should == true
-  end
+  it { expect(true).to be true }
 end

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -129,16 +129,24 @@ describe ForkingTestRunner do
   end
 
   describe "rspec" do
-    it "can run" do
-      runner("spec --rspec").should include "1 example, 0 failures"
+    it "can run passing tests" do
+      runner("spec/passing --rspec").should include "1 example, 0 failures"
+    end
+
+    it "returns a successful status code on passing tests" do
+      runner("spec/passing --rspec")
+    end
+
+    it "can run failing tests" do
+      runner("spec/failing --rspec", { fail: true }).should include "1 example, 1 failure"
     end
 
     it "runs with arguments" do
-      runner("spec --rspec --seed 12345").should include "Randomized with seed 12345"
+      runner("spec/passing --rspec --seed 12345").should include "Randomized with seed 12345"
     end
 
     it "runs with and groups" do
-      runner("spec --rspec --group 1 --groups 1 --seed 12345").should include "Randomized with seed 12345"
+      runner("spec/passing --rspec --group 1 --groups 1 --seed 12345").should include "Randomized with seed 12345"
     end
   end
 end


### PR DESCRIPTION
Thanks for your work on this gem! I've been using it to mitigate some memory issues in a large RSpec/Capybara test suite on Travis CI with success, but I did notice that the overall `forking-test-runner` command was finishing with an exit code of 0 despite some failures - this patch got me working.