### PR TITLE
Add a test that exercises STDERR from the child process

### DIFF
--- a/spec/dummy/spec/emitting/simple_spec.rb
+++ b/spec/dummy/spec/emitting/simple_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+describe "Foo" do
+  class DummyClass
+    def self.method_under_test
+      STDERR.puts 'Warning: Code Under Test'
+      true
+    end
+  end
+
+  it { expect(DummyClass.method_under_test).to be true }
+end

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -148,5 +148,19 @@ describe ForkingTestRunner do
     it "runs with and groups" do
       runner("spec/passing --rspec --group 1 --groups 1 --seed 12345").should include "Randomized with seed 12345"
     end
+
+    context 'when emitting debug' do
+      context 'without --quiet' do
+        let(:output_with_debug) { runner("spec/emitting --rspec") }
+
+        it { output_with_debug.should include('Warning: Code Under Test') }
+      end
+
+      context 'with --quiet' do
+        let(:output_with_debug) { runner("spec/emitting --rspec --quiet") }
+
+        it { output_with_debug.should include('Warning: Code Under Test') }
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a small test-only addition - when using the gem the question of whether or not `STDERR` output from the child process was silenced by the `--quiet` flag came up.

It isn't, which is good behaviour so I've just added a test to describe that behaviour.