### PR TITLE
add support for rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 bundler_args: ""
 sudo: false
 rvm:
-  - 2.0.0
-  - 2.1.8
   - 2.2.4
   - 2.3.1
 script: bundle exec rake spec
@@ -14,4 +12,5 @@ gemfile:
  - gemfiles/40.gemfile
  - gemfiles/41.gemfile
  - gemfiles/42.gemfile
+ - gemfiles/50.gemfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 bundler_args: ""
 sudo: false
 rvm:
+  - 2.0.0
+  - 2.1.8
   - 2.2.4
   - 2.3.1
 script: bundle exec rake spec
@@ -13,4 +15,9 @@ gemfile:
  - gemfiles/41.gemfile
  - gemfiles/42.gemfile
  - gemfiles/50.gemfile
-
+matrix:
+  exclude:
+  - rvm: 2.0.0
+    gemfile: gemfiles/50.gemfile
+  - rvm: 2.1.8
+    gemfile: gemfiles/50.gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     forking_test_runner (0.7.0)
-      activerecord (< 5.0.0)
+      activerecord (< 6.0.0)
       parallel_tests (>= 1.3.7)
 
 GEM
@@ -16,7 +16,7 @@ GEM
       activerecord-deprecated_finders (~> 1.0.2)
       activesupport (= 4.0.13)
       arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
+    activerecord-deprecated_finders (1.0.4)
     activesupport (4.0.13)
       i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
@@ -29,9 +29,9 @@ GEM
     diff-lcs (1.2.5)
     i18n (0.7.0)
     minitest (4.7.5)
-    multi_json (1.11.0)
-    parallel (1.4.1)
-    parallel_tests (1.3.7)
+    multi_json (1.12.1)
+    parallel (1.6.1)
+    parallel_tests (2.0.0)
       parallel
     rake (10.4.2)
     rspec (3.2.0)
@@ -49,7 +49,7 @@ GEM
     rspec-support (3.2.2)
     sqlite3 (1.3.11)
     thread_safe (0.3.5)
-    tzinfo (0.3.43)
+    tzinfo (0.3.46)
     wwtd (0.8.0)
 
 PLATFORMS

--- a/forking_test_runner.gemspec
+++ b/forking_test_runner.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new name, ForkingTestRunner::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib/ bin/ MIT-LICENSE`.split("\n")
   s.add_runtime_dependency "parallel_tests", ">= 1.3.7"
-  s.add_runtime_dependency "activerecord", "< 6.0.0"
+  s.add_runtime_dependency "activerecord", "< 5.1.0"
   s.add_development_dependency "wwtd"
   s.add_development_dependency "bump"
   s.add_development_dependency "rake"

--- a/forking_test_runner.gemspec
+++ b/forking_test_runner.gemspec
@@ -8,14 +8,14 @@ Gem::Specification.new name, ForkingTestRunner::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib/ bin/ MIT-LICENSE`.split("\n")
   s.add_runtime_dependency "parallel_tests", ">= 1.3.7"
-  s.add_runtime_dependency "activerecord", "< 5.0.0"
+  s.add_runtime_dependency "activerecord", "< 6.0.0"
   s.add_development_dependency "wwtd"
   s.add_development_dependency "bump"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.2.0'
 
   s.executables = ["forking-test-runner"]
   s.license = "MIT"

--- a/gemfiles/32.gemfile.lock
+++ b/gemfiles/32.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.6.0)
-      activerecord (< 5.0.0)
+    forking_test_runner (0.7.0)
+      activerecord (< 6.0.0)
       parallel_tests (>= 1.3.7)
 
 GEM
@@ -27,7 +27,7 @@ GEM
     minitest (4.7.5)
     multi_json (1.11.0)
     parallel (1.9.0)
-    parallel_tests (2.6.0)
+    parallel_tests (2.7.1)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/40.gemfile.lock
+++ b/gemfiles/40.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.6.0)
-      activerecord (< 5.0.0)
+    forking_test_runner (0.7.0)
+      activerecord (< 6.0.0)
       parallel_tests (>= 1.3.7)
 
 GEM
@@ -31,7 +31,7 @@ GEM
     minitest (4.7.5)
     multi_json (1.11.0)
     parallel (1.9.0)
-    parallel_tests (2.6.0)
+    parallel_tests (2.7.1)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/41.gemfile.lock
+++ b/gemfiles/41.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.6.0)
-      activerecord (< 5.0.0)
+    forking_test_runner (0.7.0)
+      activerecord (< 6.0.0)
       parallel_tests (>= 1.3.7)
 
 GEM
@@ -29,7 +29,7 @@ GEM
     json (1.8.2)
     minitest (5.5.1)
     parallel (1.9.0)
-    parallel_tests (2.6.0)
+    parallel_tests (2.7.1)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/42.gemfile.lock
+++ b/gemfiles/42.gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: ../
   specs:
-    forking_test_runner (0.6.0)
-      activerecord (< 5.0.0)
+    forking_test_runner (0.7.0)
+      activerecord (< 6.0.0)
       parallel_tests (>= 1.3.7)
 
 GEM
@@ -29,7 +29,7 @@ GEM
     json (1.8.2)
     minitest (5.5.1)
     parallel (1.9.0)
-    parallel_tests (2.6.0)
+    parallel_tests (2.7.1)
       parallel
     rake (10.4.2)
     rspec (3.2.0)

--- a/gemfiles/50.gemfile
+++ b/gemfiles/50.gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec path: "../"
+
+gem 'activerecord', '~> 5.0.0'

--- a/gemfiles/50.gemfile.lock
+++ b/gemfiles/50.gemfile.lock
@@ -1,0 +1,65 @@
+PATH
+  remote: ../
+  specs:
+    forking_test_runner (0.7.0)
+      activerecord (< 6.0.0)
+      parallel_tests (>= 1.3.7)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activerecord (5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      arel (~> 7.0)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (7.1.1)
+    bump (0.5.3)
+    concurrent-ruby (1.0.2)
+    diff-lcs (1.2.5)
+    i18n (0.7.0)
+    minitest (5.9.0)
+    parallel (1.9.0)
+    parallel_tests (2.7.1)
+      parallel
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    sqlite3 (1.3.11)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    wwtd (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activerecord (~> 5.0.0)
+  bump
+  forking_test_runner!
+  minitest
+  rake
+  rspec
+  sqlite3
+  wwtd
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
/cc @grosser 

might want to bump to version 1.0 since we can't support both rails 5 and ruby 2.1 or lower. 