### PR TITLE
record coverage for things loaded via fixtures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,28 +8,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.0.13)
-      activesupport (= 4.0.13)
-      builder (~> 3.1.0)
-    activerecord (4.0.13)
-      activemodel (= 4.0.13)
-      activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.13)
-      arel (~> 4.0.0)
-    activerecord-deprecated_finders (1.0.3)
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-    arel (4.0.2)
-    builder (3.1.4)
+    activemodel (5.0.1)
+      activesupport (= 5.0.1)
+    activerecord (5.0.1)
+      activemodel (= 5.0.1)
+      activesupport (= 5.0.1)
+      arel (~> 7.0)
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (7.1.4)
     bump (0.5.1)
+    concurrent-ruby (1.0.4)
     diff-lcs (1.2.5)
     i18n (0.7.0)
-    minitest (4.7.5)
-    multi_json (1.11.0)
+    minitest (5.10.1)
     parallel (1.4.1)
     parallel_tests (1.3.7)
       parallel
@@ -49,7 +44,8 @@ GEM
     rspec-support (3.2.2)
     sqlite3 (1.3.11)
     thread_safe (0.3.5)
-    tzinfo (0.3.43)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     wwtd (1.3.0)
 
 PLATFORMS
@@ -65,4 +61,4 @@ DEPENDENCIES
   wwtd
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/forking_test_runner.gemspec
+++ b/forking_test_runner.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new name, ForkingTestRunner::VERSION do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "minitest"
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.executables = ["forking-test-runner"]
   s.license = "MIT"

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -338,7 +338,7 @@ module ForkingTestRunner
 
         if value
           minitest_class.autorun
-          require "./#{file}"
+          require(file.start_with?('/') ? file : "./#{file}")
         end
       end
     end

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -66,6 +66,11 @@ module ForkingTestRunner
         puts "Running tests #{tests.map(&:first).join(" ")}"
       end
 
+      if ar?
+        preload_fixtures
+        ActiveRecord::Base.connection.disconnect!
+      end
+
       Coverage.capture_coverage! if @merge_coverage
 
       # run all the tests
@@ -198,8 +203,7 @@ module ForkingTestRunner
     # This forces Rails to load all fixtures, then prevents it from
     # "deleting and re-inserting all fixtures" when a new connection is used (forked).
     def preload_fixtures
-      return if @preloaded || @no_fixtures
-      @preloaded = true
+      return if @no_fixtures
 
       fixtures = (ActiveSupport::VERSION::MAJOR == 3 ? ActiveRecord::Fixtures : ActiveRecord::FixtureSet)
 
@@ -251,11 +255,6 @@ module ForkingTestRunner
     end
 
     def run_test(file)
-      if ar?
-        preload_fixtures
-        ActiveRecord::Base.connection.disconnect!
-      end
-
       output = change_program_name_to file do
         fork_with_captured_output(!@quiet) do
           SimpleCov.pid = Process.pid if defined?(SimpleCov) && SimpleCov.respond_to?(:pid=) # trick simplecov into reporting in this fork

--- a/spec/dummy/fixtures/users.yml
+++ b/spec/dummy/fixtures/users.yml
@@ -1,3 +1,4 @@
 <% $fixtures_loaded ||= 0; $fixtures_loaded += 1 %>
+<% User.coverage_test %>
 foo:
   name: Foo

--- a/spec/dummy/lib/user.rb
+++ b/spec/dummy/lib/user.rb
@@ -1,0 +1,5 @@
+class User < ActiveRecord::Base
+  def self.coverage_test
+    111
+  end
+end

--- a/spec/dummy/setup_test_model.rb
+++ b/spec/dummy/setup_test_model.rb
@@ -1,11 +1,13 @@
 require 'bundler/setup'
 require 'active_record'
 
+$LOAD_PATH << File.expand_path('../lib', __FILE__)
+
 # connect
 ActiveRecord::Base.configurations = {
   "test" => {
-    :adapter => "sqlite3",
-    :database => File.expand_path("../db.sqlite", __FILE__)
+    adapter: "sqlite3",
+    database: File.expand_path("../db.sqlite", __FILE__)
   }
 }
 
@@ -14,15 +16,14 @@ ActiveRecord::Base.establish_connection key
 
 # create tables
 ActiveRecord::Schema.verbose = false
-ActiveRecord::Schema.define(:version => 1) do
+ActiveRecord::Schema.define(version: 1) do
   create_table :users, force: true do |t|
     t.string :name
   end
 end
 
-# create models
-class User < ActiveRecord::Base
-end
+# create models ... also make sure that fixture loading is covered
+autoload :User, 'user'
 
 # Logging in case something is weird
 # ActiveRecord::Base.logger = Logger.new(STDOUT)
@@ -33,9 +34,3 @@ ActiveSupport::TestCase.send(:include, ActiveRecord::TestFixtures)
 
 # have to tell AS where to find fixtures or it looks into the the root directory ...
 ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
-
-class << ActiveSupport::TestCase
-  # we cannot load the models for our fixtures
-  def self.try_to_load_dependency(file)
-  end
-end

--- a/spec/dummy/test/coverage.rb
+++ b/spec/dummy/test/coverage.rb
@@ -1,2 +1,5 @@
 PreloadedCoverage.generate_coverage_after_fork
-puts "preloaded: " + Coverage.result.fetch(File.expand_path("../preloaded.rb", __FILE__)).inspect
+result = Coverage.result
+user = result.fetch(File.expand_path('../../lib/user.rb', __FILE__))
+preloaded = result.fetch(File.expand_path("../preloaded.rb", __FILE__))
+puts "user: #{user.inspect} preloaded: #{preloaded.inspect}"

--- a/spec/dummy/test/loaded_from_fixtures.rb
+++ b/spec/dummy/test/loaded_from_fixtures.rb
@@ -1,0 +1,5 @@
+class LoadedFromFixtures
+  def test
+    1
+  end
+end

--- a/spec/dummy/test/test_helper.rb
+++ b/spec/dummy/test/test_helper.rb
@@ -6,4 +6,4 @@ if ENV["COVERAGE"]
 end
 
 require_relative "../setup_test_model"
-require_relative "../test/no_ar_helper"
+require_relative "no_ar_helper"

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "tempfile"
+require "active_record/version"
 
 describe ForkingTestRunner do
   let(:root) { File.expand_path("../../", __FILE__) }
@@ -115,7 +116,7 @@ describe ForkingTestRunner do
       result = with_env "COVERAGE" => "1" do
         runner("test/coverage.rb --merge-coverage")
       end
-      if ActiveRecord::Base::VERSION < "5.0.0"
+      if ActiveRecord::VERSION::STRING < "4.2.0"
         # older rails versions do some evil monkey patching that prevents us from recording coverage during fixture load
         result.should include "user: [1, 1, 0, nil, nil] preloaded: [1, 1, 1, nil, nil, 1, 1, nil, nil]"
       else

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -62,6 +62,11 @@ describe ForkingTestRunner do
     result.should_not include "Time:" # no runtime log -> no time info
   end
 
+  it "runs absolute files" do
+    result = runner(File.expand_path('../dummy/test/simple_test.rb', __FILE__))
+    result.should include "simple_test.rb"
+  end
+
   it "fails when a test fails" do
     with_env "FAIL_NOW" => "1" do
       result = runner("test", fail: true)

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -115,7 +115,12 @@ describe ForkingTestRunner do
       result = with_env "COVERAGE" => "1" do
         runner("test/coverage.rb --merge-coverage")
       end
-      result.should include "preloaded: [1, 1, 1, nil, nil, 1, 1, nil, nil]"
+      if ActiveRecord::Base::VERSION < "5.0.0"
+        # older rails versions do some evil monkey patching that prevents us from recording coverage during fixture load
+        result.should include "user: [1, 1, 0, nil, nil] preloaded: [1, 1, 1, nil, nil, 1, 1, nil, nil]"
+      else
+        result.should include "user: [1, 1, 1, nil, nil] preloaded: [1, 1, 1, nil, nil, 1, 1, nil, nil]"
+      end
     end
   else
     it "explodes when trying to use coverage" do


### PR DESCRIPTION
there is some evil magic inside rails 4.0 fixtures that prevents this from capturing properly,
but works fine on rails 5