### PR TITLE
Add support for Buildkite environment

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ forking-test-runner folder [options]
     --no-fixtures                Do not load fixtures
     --no-ar                      Disable ActiveRecord logic
     --merge-coverage             Merge base code coverage into indvidual files coverage, great for SingleCov
-    --record-runtime=MODE        
+    --record-runtime=MODE
       Record test runtime:
         simple = write to disk at --runtime-log)
         amend  = write from multiple remote workers via http://github.com/grosser/amend, needs TRAVIS_REPO_SLUG & TRAVIS_BUILD_NUMBER
@@ -94,6 +94,11 @@ forking-test-runner folder [options]
     --help                       Show help
 ```
 <!-- Updated by rake bump:patch -->
+
+### Supported CI Providers
+
+ * Travis CI (TRAVIS_REPO_SLUG, TRAVIS_BUILD_NUMBER)
+ * Buildkite (BUILDKITE_ORGANIZATION_SLUG, BUILDKITE_PIPELINE_SLUG, BUILDKITE_JOB_ID)
 
 ### Log aggregation
 

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -184,7 +184,7 @@ module ForkingTestRunner
           id = ENV.fetch("BUILDKITE_JOB_ID")
         else
           raise "No env found for a CI provider"
-        done
+        end
 
         url = "https://amend.herokuapp.com/amend/#{slug}-#{id}"
 

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -176,8 +176,16 @@ module ForkingTestRunner
       when 'simple'
         File.write(log, data)
       when 'amend'
-        slug = ENV.fetch("TRAVIS_REPO_SLUG").sub("/", "-")
-        id = ENV.fetch("TRAVIS_BUILD_NUMBER")
+        if ENV.has_key? "TRAVIS_REPO_SLUG" &&  ENV.has_key? "TRAVIS_BUILD_NUMBER"
+          slug = ENV.fetch("TRAVIS_REPO_SLUG").sub("/", "-")
+          id = ENV.fetch("TRAVIS_BUILD_NUMBER"
+        elsif ENV.has_key? "BUILDKITE_PIPELINE_SLUG" && ENV.has_key? "BUILDKITE_JOB_ID"
+          slug = ENV.fetch("BUILDKITE_ORG_SLUG") + "-" + ENV.fetch("BUILDKITE_PIPELINE_SLUG")
+          id = ENV.fetch("BUILDKITE_JOB_ID")
+        else
+          raise "No env found for a CI provider"
+        done
+
         url = "https://amend.herokuapp.com/amend/#{slug}-#{id}"
 
         require 'tempfile'


### PR DESCRIPTION
We support parallelism on Buildkite that seems like it should work nicely with the groups support here. This adds support for the relevant env.

More details at https://buildkite.com/docs/tutorials/parallel-builds.

Ruby is not my native language, so please let me know if I'm doing it wrong. 