### PR TITLE
make sure to not run only a single group when user requested multiple…

### DIFF
--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -21,6 +21,7 @@ module ForkingTestRunner
         if parallel && !@options.fetch(:group)
           Array.new(parallel) { |i| find_tests_for_group(i + 1, parallel, tests, runtime_log) }
         else
+          raise ArgumentError, "Use the same amount of processors as groups" if parallel && parallel != group_count
           groups.map { |group| find_tests_for_group(group, group_count, tests, runtime_log) }
         end
 

--- a/spec/dummy/test/warn_1.rb
+++ b/spec/dummy/test/warn_1.rb
@@ -1,3 +1,4 @@
 STDERR.sync = true
+sleep 0.01 # make newlines from warn_2 print slightly before this WARNING
 warn "WARNING"
 sleep 0.1

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -273,6 +273,11 @@ describe ForkingTestRunner do
       TEXT
     end
 
+    it "fails when processor count makes no sense for given group count" do
+      result = runner("test/warn_1.rb test/warn_2.rb --groups 6 --group 1,2 --parallel 3 --helper test/no_ar_helper.rb", fail: true)
+      result.should include "ArgumentError: Use the same amount of processors as groups"
+    end
+
     it "can work quietly" do
       result = runner("test/warn_1.rb test/warn_2.rb --parallel 2 --helper test/no_ar_helper.rb --quiet")
       result.gsub!(/warn_\d/, "warn_d") || raise


### PR DESCRIPTION
… processors but a single group