### PR TITLE
Improve SimpleCov compatibility

### DIFF
--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -282,7 +282,10 @@ module ForkingTestRunner
     def run_test(file)
       stdout = change_program_name_to file do
         fork_with_captured_stdout do
-          SimpleCov.pid = Process.pid if defined?(SimpleCov) && SimpleCov.respond_to?(:pid=) # make simplecov report in this fork
+          if defined?(SimpleCov)
+            SimpleCov.pid = Process.pid
+            SimpleCov.command_name file
+          end
           if partial_reports_for_single_cov?
             SingleCov.coverage_report = "#{CONVERAGE_REPORT_PREFIX}#{Process.pid}.json"
           end

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -253,7 +253,7 @@ module ForkingTestRunner
     def fork_with_captured_stdout
       rpipe, wpipe = IO.pipe
 
-      child = fork do
+      child = Process.fork do
         rpipe.close
         preserve_tty { $stdout.reopen(wpipe) }
         yield


### PR DESCRIPTION
1) SimpleCov [patches](https://github.com/simplecov-ruby/simplecov/blob/main/lib/simplecov/process.rb) `Process.fork` to implement [at_fork](https://github.com/simplecov-ruby/simplecov#running-simplecov-against-subprocesses) hook. Call `Process.fork` instead so that this hook works.

2) Set SimpleCov command name to the test name after forking, so that coverage results are merged correctly instead of overwriting each other. (If fix 1 is merged, special after-fork behavior for SimpleCov could actually be removed entirely from this gem. Downstream consumers can use the SimpleCov at_fork hook to add this behavior. It would be cleaner this way, let me know if you prefer this.)