### PR TITLE
Add support for before_fork and after_fork callbacks

### DIFF
--- a/spec/dummy/test/test_helper.rb
+++ b/spec/dummy/test/test_helper.rb
@@ -11,3 +11,16 @@ end
 
 require_relative "../setup_test_model"
 require_relative "no_ar_helper"
+
+if ENV.key?("DUMMY_SPEC_CALLBACK_FILE")
+  ForkingTestRunner.before_fork_callbacks << Proc.new do
+    File.open(ENV["DUMMY_SPEC_CALLBACK_FILE"], 'a') do |f|
+      f.write "before_fork_called\n"
+    end
+  end
+  ForkingTestRunner.after_fork_callbacks << Proc.new do
+    File.open(ENV["DUMMY_SPEC_CALLBACK_FILE"], 'a') do |f|
+      f.write "after_fork_called\n"
+    end
+  end
+end

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -317,6 +317,24 @@ describe ForkingTestRunner do
     end
   end
 
+  describe "before_fork_callbacks and after_fork_callbacks" do
+    before do
+      @tempfile = Tempfile.new
+    end
+
+    after do
+      @tempfile.close
+      @tempfile.unlink
+    end
+
+    it "runs them" do
+      with_env("DUMMY_SPEC_CALLBACK_FILE" =>  @tempfile.path) do
+        runner("test/simple_test.rb")
+      end
+      @tempfile.read.should == "before_fork_called\nafter_fork_called\n"
+    end
+  end
+
   describe "rspec" do
     it "can run passing tests" do
       runner("spec/passing --rspec").should include "1 example, 0 failures"


### PR DESCRIPTION
These are useful if you need to do some work (like closing DB
connections and the like):

* before_fork: After the spec helper & fixtures are loaded (in each
  parallel process), but before the first testcase is forked off
* after_fork: In each testcase, immediately after it is forked off