### PR TITLE
POC add option to not merge unrelated coverage

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -106,6 +106,7 @@ forking-test-runner folder [options]
     --no-fixtures                Do not load fixtures
     --no-ar                      Disable ActiveRecord logic
     --merge-coverage             Merge base code coverage into individual files coverage and summarize coverage report
+    --only-merge-configured      Do not merge unconfigured coverage to avoid overhead (needs --merge-coverage)
     --record-runtime=MODE        
       Record test runtime:
         simple = write to disk at --runtime-log)

--- a/lib/forking_test_runner.rb
+++ b/lib/forking_test_runner.rb
@@ -203,7 +203,12 @@ module ForkingTestRunner
       end
       @before_fork_callbacks.each(&:call)
 
-      CoverageCapture.capture! if @options.fetch(:merge_coverage)
+      if @options.fetch(:merge_coverage)
+        CoverageCapture.capture!
+        if @options.fetch(:only_merge_configured)
+          CoverageCapture.coverage.delete_if { |f| !SingleCov::COVERAGES["#{SingleCov.send(:root)}/#{f}"] }
+        end
+      end
     end
 
     def reraise_clean_ar_error

--- a/lib/forking_test_runner/cli.rb
+++ b/lib/forking_test_runner/cli.rb
@@ -8,6 +8,7 @@ module ForkingTestRunner
       [:no_fixtures, "--no-fixtures", "Do not load fixtures"],
       [:no_ar, "--no-ar", "Disable ActiveRecord logic"],
       [:merge_coverage, "--merge-coverage", "Merge base code coverage into individual files coverage and summarize coverage report"],
+      [:only_merge_configure, "--only-merge-configure", "Do not merge unconfigured coverage to avoid overhead (needs --merge-coverage)"],
       [
         :record_runtime,
         "--record-runtime=MODE",

--- a/spec/forking_test_runner_spec.rb
+++ b/spec/forking_test_runner_spec.rb
@@ -189,6 +189,14 @@ describe ForkingTestRunner do
     result.should include "user: {:lines=>[1, 1, 1, nil, nil], :branches=>{[:if, 0, 3, 4, 3, 36]=>{[:then, 1, 3, 4, 3, 8]=>0, [:else, 2, 3, 4, 3, 36]=>1}}} preloaded: {:lines=>[1, 1, 1, nil, nil, 1, 1, nil, nil], :branches=>{}}"
   end
 
+  it "drops uncovered if requested" do
+    result = with_env "COVERAGE" => "branches" do
+      runner("test/coverage.rb --merge-coverage --only-merge-configured")
+    end
+    puts result
+    result.should include ""
+  end
+
   it "can merge branch coverage" do
     ForkingTestRunner::CoverageCapture.merge_coverage(
       {"foo.rb" => {lines: [1,2,3], branches: {foo: {bar: 0, baz: 1}}}},


### PR DESCRIPTION
it's not a great default since for 9X% of apps it does not matter and it removes coverage insights into unconfigured files